### PR TITLE
[13may2020] Added support for uploading and parsing the facebook donation transaction report

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "facebook-reclass",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "@reduxjs/toolkit": "^1.1.0",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-redux": "^7.1.3",
-    "react-scripts": "3.4.1",
-    "redux-thunk": "^2.3.0",
-    "xlsx": "^0.16.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+    "name": "facebook-reclass",
+    "version": "0.1.0",
+    "private": true,
+    "dependencies": {
+        "@reduxjs/toolkit": "^1.1.0",
+        "@testing-library/jest-dom": "^4.2.4",
+        "@testing-library/react": "^9.3.2",
+        "@testing-library/user-event": "^7.1.2",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
+        "react-redux": "^7.1.3",
+        "react-scripts": "3.4.1",
+        "redux-thunk": "^2.3.0",
+        "xlsx": "^0.16.0"
+    },
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
+    },
+    "eslintConfig": {
+        "extends": "react-app"
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    }
 }

--- a/src/actions/facebook_donactions_upload.js
+++ b/src/actions/facebook_donactions_upload.js
@@ -1,0 +1,6 @@
+import { ACTION_TYPES, DEFAULT_REDUCERS } from '../constants';
+
+export const setFacebookDonations = (facebookDonations = DEFAULT_REDUCERS.FACEBOOK_DONATIONS) => ({
+    type: ACTION_TYPES.SET_FACEBOOK_DONATIONS,
+    facebookDonations
+});

--- a/src/actions/volunteer_file_upload.js
+++ b/src/actions/volunteer_file_upload.js
@@ -1,4 +1,4 @@
-import { ACTION_TYPES, DEFAULT_REDUCERS } from '../common';
+import { ACTION_TYPES, DEFAULT_REDUCERS } from '../constants';
 
 export const setVolunteers = (volunteers = DEFAULT_REDUCERS.VOLUNTEERS) => ({
     type: ACTION_TYPES.SET_VOLUNTEERS,

--- a/src/common.js
+++ b/src/common.js
@@ -1,7 +1,0 @@
-export const ACTION_TYPES = {
-    SET_VOLUNTEERS: 'SET_VOLUNTEERS'
-};
-
-export const DEFAULT_REDUCERS = {
-    VOLUNTEERS: []
-};

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,18 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import { FacebookDonationUpload } from './FacebookDonationUpload';
 import { VolunteerFileUpload } from './VolunteerFileUpload';
 import { VolunteerList } from './VolunteerList';
 
 import { setVolunteers } from '../actions/volunteer_file_upload';
+import { setFacebookDonations } from '../actions/facebook_donactions_upload';
 
 export const App = (props) => {
-    const { setVolunteers, volunteers } = props;
+    const {
+        setFacebookDonations,
+        setVolunteers,
+        volunteers
+    } = props;
     return (
         <div className='app'>
             <div className='volunteer-uploader'>
                 <VolunteerFileUpload setVolunteers={setVolunteers} volunteers={volunteers} />
                 <VolunteerList volunteers={volunteers} />
+                <FacebookDonationUpload setFacebookDonations={setFacebookDonations} volunteers={volunteers} />
             </div>
         </div>
     );
@@ -32,7 +39,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    setVolunteers: volunteers => dispatch(setVolunteers(volunteers))
+    setVolunteers: volunteers => dispatch(setVolunteers(volunteers)),
+    setFacebookDonations: facebookDonations => dispatch(setFacebookDonations(facebookDonations))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/components/FacebookDonationUpload.jsx
+++ b/src/components/FacebookDonationUpload.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { extractCSVData } from '../helpers';
+
+export class FacebookDonationUpload extends React.Component {
+    constructor() {
+        super();
+        this.onFileUpload = this.onFileUpload.bind(this);
+    }
+
+    onFileUpload(file) {
+        const { setFacebookDonations, volunteers } = this.props;
+
+        const fileReader = new FileReader();
+        fileReader.onload = ({ target }) => {
+            const facebookDonations = extractCSVData({
+                csvText: target.result,
+                lineTerminator: '\n',
+                cellTerminator: ',',
+                volunteers
+            });
+            setFacebookDonations(facebookDonations);
+        }
+        fileReader.readAsText(file);
+    }
+
+    render() {
+        window.volunteers = this.props.volunteers;
+        return (
+            <div className='donation-uploader__container'>
+                <input type='file' onChange={({ target }) => this.onFileUpload(target.files[0])} />
+            </div>
+        );
+    }
+}
+
+FacebookDonationUpload.propTypes = {
+    volunteers: PropTypes.array.isRequired
+};

--- a/src/components/VolunteerList.jsx
+++ b/src/components/VolunteerList.jsx
@@ -13,7 +13,7 @@ export const VolunteerList = (props) => {
         <div className='volunteer-list'>
             <ol className='volunteer-list__volunteers'>
                 {
-                    volunteers.map(volunteer => <VolunteerListItem volunteer={volunteer} />)
+                    volunteers.map((volunteer, idx) => <VolunteerListItem volunteer={volunteer} key={idx} />)
                 }
             </ol>
         </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,98 @@
+export const ACTION_TYPES = {
+    SET_VOLUNTEERS: 'SET_VOLUNTEERS',
+    SET_FACEBOOK_DONATIONS: 'SET_FACEBOOK_DONATIONS'
+};
+
+export const DEFAULT_REDUCERS = {
+    VOLUNTEERS: [],
+    FACEBOOK_DONATIONS: []
+};
+
+export const FB_DONATION_CSV_MAP = [
+    'paymentId',
+    'chargeTime',
+    'donationAmount',
+    'fbFee',
+    'netPayoutAmount',
+    'payoutCurrency',
+    'senderCurrency',
+    'taxAmount',
+    'taxUSDAmount',
+    'chargeActionTime',
+    'chargeDate',
+    'firstName',
+    'lastName',
+    'email',
+    'campaignId',
+    'fundraiserTitle',
+    'sourceName',
+    'permalink',
+    'charityId',
+    'campaignOwnerName',
+    'paymentProcessor',
+    'matchingDonation',
+    'fundraiserType',
+    'chargeTimePT'
+];
+
+export const FB_DONATION_TRANSFORM_MAP = {
+    SALES_RECEIPT_NUMBER: {
+        label: 'Sales Receipt No',
+        id: 'salesReceiptNumber'
+    },
+    CUSTOMER: {
+        label: 'Customer',
+        id: 'customer'
+    },
+    SALES_RECEIPT_DATE: {
+        label: 'Sales Receipt Date',
+        id: 'salesReceiptDate'
+    },
+    DEPOSIT_TO: {
+        label: 'Deposit To',
+        id: 'depositTo'
+    },
+    PAYMENT_METHOD: {
+        label: 'Payment Method',
+        id: 'paymentMethod'
+    },
+    REFERENCE_NUMBER: {
+        label: 'Reference No',
+        id: 'referenceNumber'
+    },
+    MEMO: {
+        label: 'Memo',
+        id: 'memo'
+    },
+    RECEIPT_MESSAGE: {
+        label: 'Message displayed on sales receipt',
+        id: 'receiptMessage'
+    },
+    EMAIL: {
+        label: 'Email',
+        id: 'email'
+    },
+    PRODUCT: {
+        label: 'Product/Service',
+        id: 'product'
+    },
+    DESCRIPTION: {
+        label: 'Product/Service Description',
+        id: 'description'
+    },
+    QUALTITY: {
+        label: 'Product/Service Quantity',
+        id: 'qualtity'
+    },
+    AMOUNT: {
+        label: 'Product/Service Amount',
+        id: 'amount'
+    }
+};
+
+export const FB_DONATION_SOURCE_MAP = {
+    fundraiser: '1) Donations:FB Donations - Fundraiser',
+    donate_button_user_posts: '1) Donations:FB Donations - Button'
+};
+
+export const ORDERED_SALES_RECEIPT_HEADERS = Object.values(FB_DONATION_TRANSFORM_MAP).map(header => header.label).join(',');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,53 @@
+import {
+    FB_DONATION_CSV_MAP,
+    FB_DONATION_TRANSFORM_MAP,
+    ORDERED_SALES_RECEIPT_HEADERS
+} from './constants';
+import { transformDonationData } from './transformers';
+
+export const titleCase = (str) => str
+    .toLowerCase()
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+export const exportTransformedCSV = (facebookDonations) => {
+    const customerCSVData = facebookDonations.map((facebookDonation) => {
+        return Object.keys(facebookDonation).reduce(function (acc, curr, idx) {
+            const columnKey = Object.values(FB_DONATION_TRANSFORM_MAP)[idx].id;
+            const cellData = facebookDonation[columnKey];
+            return acc ? `${acc},${cellData}` : cellData;
+        }, '');
+    });
+    const salesReceiptCSVData = [ORDERED_SALES_RECEIPT_HEADERS, ...customerCSVData];
+    var hiddenElement = document.createElement('a');
+    hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(salesReceiptCSVData.join('\n'));
+    hiddenElement.target = '_blank';
+    hiddenElement.download = 'people.csv';
+    hiddenElement.click();
+};
+
+export const extractCSVData = ({ csvText, lineTerminator, cellTerminator, volunteers }) => {
+    const csvRows = csvText.split(lineTerminator);
+    const donationRows = csvRows.slice(1);
+    return donationRows.map(donationRow => {
+        const donationData = donationRow.split(cellTerminator);
+        const extractedDonationData = extractDonationData(donationData);
+
+        return transformDonationData(extractedDonationData, volunteers);
+    });
+};
+
+export const referenceNumberOrNone = (campaignOwnerName, customerName, volunteers) => {
+    if (volunteers.indexOf(customerName) >= 0) {
+        return customerName;
+    } else if (volunteers.indexOf(campaignOwnerName) >= 0) {
+        return campaignOwnerName;
+    }
+    return '';
+}
+
+export const extractDonationData = donationData => donationData.reduce(function (acc, curr, idx) {
+    const cellKey = FB_DONATION_CSV_MAP[idx];
+    return { ...acc, [cellKey]: curr };
+}, {});

--- a/src/reducers/facebook_donation_upload.js
+++ b/src/reducers/facebook_donation_upload.js
@@ -1,0 +1,10 @@
+import { ACTION_TYPES, DEFAULT_REDUCERS } from '../constants';
+
+export const facebookDonations = (state = DEFAULT_REDUCERS.FACEBOOK_DONATIONS, action) => {
+    switch (action.type) {
+        case ACTION_TYPES.SET_FACEBOOK_DONATIONS:
+            return action.facebookDonations;
+        default:
+            return state;
+    }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import { volunteers } from './volunteer_file_upload';
+import { facebookDonations } from './facebook_donation_upload';
 
 export const rootReducer = combineReducers({
-    volunteers
+    volunteers,
+    facebookDonations
 });

--- a/src/reducers/volunteer_file_upload.js
+++ b/src/reducers/volunteer_file_upload.js
@@ -1,4 +1,4 @@
-import { ACTION_TYPES, DEFAULT_REDUCERS } from '../common';
+import { ACTION_TYPES, DEFAULT_REDUCERS } from '../constants';
 
 export const volunteers = (state = DEFAULT_REDUCERS.VOLUNTEERS, action) => {
     switch (action.type) {

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -1,0 +1,52 @@
+import {
+    FB_DONATION_SOURCE_MAP,
+    FB_DONATION_TRANSFORM_MAP
+} from './constants';
+import { titleCase, referenceNumberOrNone } from './helpers';
+
+const {
+    SALES_RECEIPT_NUMBER,
+    CUSTOMER,
+    SALES_RECEIPT_DATE,
+    DEPOSIT_TO,
+    PAYMENT_METHOD,
+    REFERENCE_NUMBER,
+    MEMO,
+    RECEIPT_MESSAGE,
+    EMAIL,
+    PRODUCT,
+    DESCRIPTION,
+    QUALTITY,
+    AMOUNT
+} = FB_DONATION_TRANSFORM_MAP;
+
+export const transformDonationData = ({
+    campaignOwnerName,
+    chargeDate,
+    email,
+    firstName,
+    fundraiserTitle,
+    lastName,
+    netPayoutAmount,
+    paymentId,
+    permalink,
+    sourceName
+}, volunteers) => {
+    const customerName = `${titleCase(firstName)} ${titleCase(lastName)}`;
+    const referenceNumber = referenceNumberOrNone(campaignOwnerName, customerName, volunteers);
+    return {
+        [SALES_RECEIPT_NUMBER.id]: paymentId,
+        [CUSTOMER.id]: customerName,
+        [SALES_RECEIPT_DATE.id]: chargeDate,
+        [DEPOSIT_TO.id]: 'Undeposited Funds',
+        [PAYMENT_METHOD.id]: 'FB',
+        [REFERENCE_NUMBER.id]: referenceNumber,
+        [MEMO.id]: permalink,
+        [RECEIPT_MESSAGE.id]: 'Thank you for donating to CHEER Seattle!',
+        [EMAIL.id]: email,
+        [PRODUCT.id]: FB_DONATION_SOURCE_MAP[sourceName],
+        [DESCRIPTION.id]: fundraiserTitle,
+        [QUALTITY.id]: '1',
+        [AMOUNT.id]: netPayoutAmount
+    }
+};


### PR DESCRIPTION
To do:
- don't use `document.createElement('a')` in react
- remove `ORDERED_SALES_RECEIPT_HEADERS` and write a script for `ORDERED_SALES_RECEIPT_HEADERS.join(',')` based on `FB_DONATION_TRANSFORM_MAP`